### PR TITLE
Fix JWT_EXPIRE env variable to resolve 500 error during registration

### DIFF
--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -122,9 +122,10 @@ userSchema.methods.matchPassword = async function (enteredPassword) {
 // Method to generate JWT token
 userSchema.methods.generateToken = function () {
   return jwt.sign({ id: this._id }, process.env.JWT_SECRET, {
-    expiresIn: process.env.JWT_EXPIRES_IN,
+    expiresIn: process.env.JWT_EXPIRE || "30d",  // default fallback
   });
 };
+
 
 // Method to generate password reset token
 userSchema.methods.createPasswordResetToken = function () {


### PR DESCRIPTION
## 📝 Pull Request

### 📌 Title
Fix JWT_EXPIRE env variable to resolve 500 error during registration

### 🔧 Changes
- Updated `.env` to use `JWT_EXPIRE=30d`
- Adjusted `generateToken` method in `user.js` to correctly use the env variable with default fallback
- Fixed internal server error caused by invalid `expiresIn` value

### 📷 Before / After

<table>
  <tr>
    <td align="center"><b>Before (500 error)</b></td>
    <td align="center"><b>After (successful registration)</b></td>
  </tr>
  <tr>
    <td>
      <img width="470" height="655" alt="Before error screenshot" src="https://github.com/user-attachments/assets/f6dd66a3-a616-4630-b2a3-4090ac6f06bf" />
    </td>
    <td>
      <img width="328" height="416" alt="After success screenshot" src="https://github.com/user-attachments/assets/e95cfe3b-5405-4103-aa73-d388209257c2" />
    </td>
  </tr>
</table>


### ✅ Testing
- Registered a new user successfully without server crash
- Verified JWT token is generated with correct expiry

### 📂 Branch
`feature/register`

---
