### PR TITLE
fix: removed the  mandatory validation for remember me checkbox

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -67,13 +67,6 @@ const Login = () => {
       );
       return;
     }
-
-    // Validate remember me checkbox must be checked
-    if (!rememberMe) {
-      setError("Please agree to the terms by checking the box.");
-      return;
-    }
-
     setLoading(true);
 
     try {


### PR DESCRIPTION
fix: remove mandatory validation for remember me checkbox

📌 Linked Issue
Connected to #117

🛠 Changes Made
- **Fixed:** Removed the validation logic in `src/pages/Login.jsx` (`handleSubmit` function) that incorrectly treated the "Remember Me" checkbox as a mandatory Terms of Service field.
- **Updated:** Users can now log in with just their email and password, regardless of whether the checkbox is selected.

🧪 Testing
- [ ] Ran unit tests (npm test)
- [x] Tested manually (describe below):
    - **Test Case 1:** Navigate to Login Page -> Enter valid credentials -> Leave "Remember Me" **UNCHECKED** -> Click Login.
    - **Expected Result:** Login proceeds successfully (or checks credentials) without displaying the "Please agree to the terms" error.

📸 UI Changes (if applicable)

Before 
 <img width="1599" height="803" alt="image" src="https://github.com/user-attachments/assets/7d56b80f-e4f9-4206-8ea8-615366aa9b2c" />
After 
<img width="1599" height="802" alt="image" src="https://github.com/user-attachments/assets/25580de7-a476-4646-b7ab-d8cee399b3d2" />
📝 Documentation Updates
- [ ] Updated README/docs
- [ ] Added code comments

✅ Checklist
- [x] Created a new branch for PR
- [x] Have starred the repository
- [x] Follows JavaScript Styleguide
- [x] No console warnings/errors
- [x] Commit messages follow Git Guidelines

💡 Additional Notes (If any)
Assigned under the SWOC26