### PR TITLE
Fix: Clicking on property type filters listings correctly

### DIFF
--- a/frontend/src/pages/Listings.jsx
+++ b/frontend/src/pages/Listings.jsx
@@ -62,6 +62,20 @@ const Listings = () => {
 
   // Reference for the categories container for horizontal scrolling
   const categoriesContainerRef = useRef(null);
+  
+  useEffect(() => {
+  const queryParams = new URLSearchParams(location.search);
+  const typeParam = queryParams.get("type");
+
+  if (typeParam) {
+    setActiveCategory(typeParam.toLowerCase());
+  } else {
+    setActiveCategory("all");
+  }
+}, [location.search]);
+
+
+
 
   /**
    * Scrolls the categories container left or right
@@ -578,7 +592,7 @@ const filteredProperties = properties.filter((property) => {
       dryer: false,
       gym: false,
     });
-    setActiveCategory("all");
+    
     // Clear experience from URL
     const queryParams = new URLSearchParams(location.search);
     queryParams.delete("experience");
@@ -634,24 +648,20 @@ const filteredProperties = properties.filter((property) => {
    * @param {string} categoryId - The ID of the clicked category
    */
   const handleCategoryClick = (categoryId) => {
+  setActiveCategory(categoryId);
 
-    // Set the active category
-    setActiveCategory(categoryId);
+  const queryParams = new URLSearchParams(location.search);
 
-    // When 'all' is selected, clear all category-related filters
-    if (categoryId === "all") {
-      setFilters({
-        ...filters,
-        propertyType: "",
-      });
-    }
+  if (categoryId === "all") {
+    queryParams.delete("type");
+  } else {
+    queryParams.set("type", categoryId.toLowerCase());
+  }
 
-    // If we're in a mobile view, scroll back to the top of results
-    window.scrollTo({
-      top: document.querySelector(".container")?.offsetTop || 0,
-      behavior: "smooth",
-    });
-  };
+  navigate(`/listings?${queryParams.toString()}`);
+};
+
+
 
   /**
    * Navigates to property detail page
@@ -1231,11 +1241,20 @@ const filteredProperties = properties.filter((property) => {
                           dryer: false,
                           gym: false,
                         });
-                        setActiveCategory("all");
-                        // Clear experience from URL
                         const queryParams = new URLSearchParams(location.search);
+                        const typeParam = queryParams.get("type");
+                        setActiveCategory(
+                          typeParam
+                          ? typeParam.charAt(0).toUpperCase() + typeParam.slice(1)
+                          : "all"
+                        );
+
+                        // Clear experience from URL
+                       
                         queryParams.delete("experience");
-                        navigate(`/listings?${queryParams.toString()}`, { replace: true });
+                        queryParams.delete("type");
+                        navigate(`/listings`, { replace: true });
+
                       }}
                       className="flex-1 px-4 py-2 border border-neutral-300 rounded-md hover:bg-neutral-100 text-neutral-600 transition-colors duration-200"
                     >


### PR DESCRIPTION
### Description:
Currently, when a user clicks on a property type such as Apartment or House, they were redirected to the generic listings page instead of seeing listings filtered by the selected type.
Issue #130
This PR fixes the issue by:
- Updating handleCategoryClick to set the active category and update the URL query string (?type=...)
- Using useEffect to read type from URL and update activeCategory
- Filtering properties dynamically based on activeCategory

###  Current Behavior (Bug):
- Clicking Apartment redirects to generic listings
- Clicking House redirects to generic listings
- URL does not reflect selected property type

### Expected Behavior (Fixed):
- Clicking Apartment shows only apartment listings
- Clicking House shows only house listings
- URL updates with ?type=apartment or ?type=house
- “All” category shows all listings

### Screenshot
<img width="1190" height="766" alt="Screenshot 2026-01-18 230343" src="https://github.com/user-attachments/assets/2b9d64b7-6feb-4991-8afe-cf378e4336a8" />
<img width="1589" height="769" alt="Screenshot 2026-01-18 230440" src="https://github.com/user-attachments/assets/dac36fc0-e209-4777-ac33-d927188ea243" />
